### PR TITLE
Makes review response policy more realistic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * For a package to be considered for the rOpenSci suite, package authors must initiate a request on the [ropensci/onboarding](https://github.com/ropensci/onboarding) repository.
 * Upon an initial assessment (see package fit below), an rOpenSci member will assign a reviewer or follow up with additional steps. This process usually happens within 5 business days.
 * Packages are reviewed for quality, fit, documentation, clarity and the review process is quite similar to a manuscript review. Unlike a manuscript review, this process will be an ongoing conversation.
-* Once all issues and questions are resolved, the editor assigned to a package will make a decision (accept, hold, or reject). Rejections are usually done early (before the review process begins), but in rare cases a package may also be rejected after review & revision.
+* Once all major issues and questions, and those addressable with reasonable effort, are resolved, the editor assigned to a package will make a decision (accept, hold, or reject). Rejections are usually done early (before the review process begins), but in rare cases a package may also be rejected after review & revision.
 
 
 ### Package fit


### PR DESCRIPTION
The policy in its original form makes the following two statements:
* Packages are reviewed for quality, fit, documentation, clarity and the review process is quite similar to a manuscript review. Unlike a manuscript review, this process will be an ongoing conversation.
* Once all issues and questions are resolved, the editor assigned to a package will make a decision (accept, hold, or reject).

Obviously, these contradict each other, because with an ongoing conversation there will arguably always be some issues and questions that are open, or at least not resolved, at any given time. The change I'm proposing is based on what I interpret the original author likely meant to say, but of course I may be off here.